### PR TITLE
Lesson 10

### DIFF
--- a/app/src/main/java/com/onay/minishop/data/ShopListRepositoryImpl.kt
+++ b/app/src/main/java/com/onay/minishop/data/ShopListRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.onay.minishop.domain.ShopItem
 import com.onay.minishop.domain.ShopListRepository
 import java.lang.RuntimeException
+import kotlin.random.Random
 
 object ShopListRepositoryImpl : ShopListRepository {
 // data зависит от репоситория  и все о нем знает и наборот
@@ -21,8 +22,8 @@ object ShopListRepositoryImpl : ShopListRepository {
     //   что бы все методы работали и добавились данные вызываем init
 
     init {
-        for (i in 0 until 10){
-            val item = ShopItem("Name $i " , i , true)
+        for (i in 0 until 1000){
+            val item = ShopItem("Name $i " , i , Random.nextBoolean())
             addShopItem(item)
         }
     }

--- a/app/src/main/java/com/onay/minishop/presentation/MainActivity.kt
+++ b/app/src/main/java/com/onay/minishop/presentation/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        setupReciclerView()
+        setupRecyclerView()
         viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
         //здесь мы подписались на LiveData , а внутри будет реализация отоброжения элеентов
         viewModel.shopList.observe(this){
@@ -25,9 +25,20 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun setupReciclerView(){
+    private fun setupRecyclerView() {
         val rvShopList = findViewById<RecyclerView>(R.id.rv_shop_list)
         adapter = ShopListAdapter()
-        rvShopList.adapter = adapter
+        rvShopList.adapter = adapter // баг был исправлен
+        with(rvShopList) {
+
+           recycledViewPool.setMaxRecycledViews(
+                ShopListAdapter.VIEW_TYPE_ENABLED,
+                ShopListAdapter.MAX_POOL_SIZE
+            )
+            recycledViewPool.setMaxRecycledViews(
+                ShopListAdapter.VIEW_TYPE_DISABLED,
+                ShopListAdapter.MAX_POOL_SIZE
+            )
+        }
     }
 }

--- a/app/src/main/java/com/onay/minishop/presentation/MainActivity.kt
+++ b/app/src/main/java/com/onay/minishop/presentation/MainActivity.kt
@@ -6,51 +6,28 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.RecyclerView
 import com.onay.minishop.R
 import com.onay.minishop.domain.ShopItem
 
 class MainActivity : AppCompatActivity() {
-    private lateinit var llShopList : LinearLayout
+
     private lateinit var viewModel: MainViewModel
+    private lateinit var adapter : ShopListAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        llShopList = findViewById(R.id.ll_shop_list)
-
-
+        setupReciclerView()
         viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
-
         //здесь мы подписались на LiveData , а внутри будет реализация отоброжения элеентов
         viewModel.shopList.observe(this){
-            showList(it)
-
-
-
-
+            adapter.ShopList = it
         }
-
     }
-    private fun showList(list: List<ShopItem>) {
-        llShopList.removeAllViews()
-        for (shopItem in list) {
-            val layoutId = if (shopItem.enabled) {
-                 R.layout.item_shop_enabled // если продукт активен
-            }else
-            {
-                R.layout.item_shop_disabled // если продукт не активен
-            }
-            val view = LayoutInflater.from(this).inflate(layoutId, llShopList, false)
-            val tvName = view.findViewById<TextView>(R.id.tv_name)
-            val tvCount = view.findViewById<TextView>(R.id.tv_count)
-            tvName.text = shopItem.name
-            tvCount.text = shopItem.count.toString()
-            view.setOnLongClickListener {
-                viewModel.changeEnableState(shopItem)
-                true
-            }
-            llShopList.addView(view)
 
-
-        }
+    private fun setupReciclerView(){
+        val rvShopList = findViewById<RecyclerView>(R.id.rv_shop_list)
+        adapter = ShopListAdapter()
+        rvShopList.adapter = adapter
     }
 }

--- a/app/src/main/java/com/onay/minishop/presentation/ShopListAdapter.kt
+++ b/app/src/main/java/com/onay/minishop/presentation/ShopListAdapter.kt
@@ -1,9 +1,11 @@
 package com.onay.minishop.presentation
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.onay.minishop.R
 import com.onay.minishop.domain.ShopItem
@@ -11,27 +13,70 @@ import com.onay.minishop.domain.ShopItem
 class ShopListAdapter : RecyclerView.Adapter<ShopListAdapter.ShopItemViewHolder>() {
 
     class ShopItemViewHolder(val view : View): RecyclerView.ViewHolder(view){
-        val TvName = view.findViewById<TextView>(R.id.tv_name)
+        val tvName = view.findViewById<TextView>(R.id.tv_name)
         val tvCount = view.findViewById<TextView>(R.id.tv_count)
     }
 
-    val list = listOf<ShopItem>()
+    var ShopList = listOf<ShopItem>()
+    set(value){
+        field = value
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShopItemViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_shop_disabled, parent , false)
+        val view = LayoutInflater.from(parent.context).inflate(
+            R.layout.item_shop_enabled,
+            parent,
+            false
+        )
         return ShopItemViewHolder(view)
     }
 
     override fun onBindViewHolder(viewHolder: ShopItemViewHolder, position: Int) {
-        val shopItem = list[position]
-        viewHolder.TvName.text = shopItem.name
-        viewHolder.tvCount.text = shopItem.count.toString()
+        val shopItem = ShopList[position]
+        val status = if(shopItem.enabled){
+            "Active"
+        }
+        else{
+            "Not Active"
+        }
+
         viewHolder.view.setOnLongClickListener {
             true
         }
+        if(shopItem.enabled){
+            viewHolder.tvName.text =" ${ shopItem.name } ${status }"
+            viewHolder.tvCount.text = shopItem.count.toString()
+            viewHolder.tvName.setTextColor(ContextCompat.getColor(viewHolder.view.context , android.R.color.holo_red_light))
+        }
+        /*
+        1 способ
+        else
+        {
+            viewHolder.tvName.text =""
+            viewHolder.tvCount.text = ""
+            viewHolder.tvName.setTextColor(ContextCompat.getColor(viewHolder.view.context , android.R.color.white))
+        }
+        решение бага в котором существующие view была переисползывана но число 2 может в 17 месте
+         */
     }
 
     override fun getItemCount(): Int {
-        return list.size
+        return ShopList.size
     }
+    /*
+    override fun getItemViewType(position: Int): Int {
+       return  position
+    }
+    не стоит исползывать
+     */
+
+    override fun onViewRecycled(viewHolder: ShopItemViewHolder) {
+        super.onViewRecycled(viewHolder)
+        viewHolder.tvName.text =""
+        viewHolder.tvCount.text = ""
+        viewHolder.tvName.setTextColor(ContextCompat.getColor(viewHolder.view.context , android.R.color.white))
+        //установлены значения по умолчанию
+
+    }
+
 }

--- a/app/src/main/java/com/onay/minishop/presentation/ShopListAdapter.kt
+++ b/app/src/main/java/com/onay/minishop/presentation/ShopListAdapter.kt
@@ -1,6 +1,7 @@
 package com.onay.minishop.presentation
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,12 +10,14 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.onay.minishop.R
 import com.onay.minishop.domain.ShopItem
+import java.lang.RuntimeException
 
 class ShopListAdapter : RecyclerView.Adapter<ShopListAdapter.ShopItemViewHolder>() {
-
+    var count = 0
     class ShopItemViewHolder(val view : View): RecyclerView.ViewHolder(view){
         val tvName = view.findViewById<TextView>(R.id.tv_name)
         val tvCount = view.findViewById<TextView>(R.id.tv_count)
+
     }
 
     var ShopList = listOf<ShopItem>()
@@ -23,31 +26,24 @@ class ShopListAdapter : RecyclerView.Adapter<ShopListAdapter.ShopItemViewHolder>
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShopItemViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(
-            R.layout.item_shop_enabled,
-            parent,
-            false
-        )
+        Log.d("ShopListAdapter", "onCreateViewHolder, count: ${++count}")
+        val layout = when (viewType) {
+            VIEW_TYPE_DISABLED -> R.layout.item_shop_disabled
+            VIEW_TYPE_ENABLED -> R.layout.item_shop_enabled
+            else -> throw RuntimeException("Unknown view type: $viewType")
+        }
+        val view = LayoutInflater.from(parent.context).inflate(layout, parent, false)
         return ShopItemViewHolder(view)
     }
 
     override fun onBindViewHolder(viewHolder: ShopItemViewHolder, position: Int) {
         val shopItem = ShopList[position]
-        val status = if(shopItem.enabled){
-            "Active"
-        }
-        else{
-            "Not Active"
-        }
-
         viewHolder.view.setOnLongClickListener {
             true
         }
-        if(shopItem.enabled){
-            viewHolder.tvName.text =" ${ shopItem.name } ${status }"
+            viewHolder.tvName.text =shopItem.name
             viewHolder.tvCount.text = shopItem.count.toString()
-            viewHolder.tvName.setTextColor(ContextCompat.getColor(viewHolder.view.context , android.R.color.holo_red_light))
-        }
+
         /*
         1 способ
         else
@@ -63,20 +59,39 @@ class ShopListAdapter : RecyclerView.Adapter<ShopListAdapter.ShopItemViewHolder>
     override fun getItemCount(): Int {
         return ShopList.size
     }
-    /*
+
     override fun getItemViewType(position: Int): Int {
-       return  position
+        val item = ShopList[position]
+        return if(item.enabled){
+            VIEW_TYPE_ENABLED
+        }else{
+            VIEW_TYPE_DISABLED
+        }
     }
+
+    /*
     не стоит исползывать
+    причина
+    когда мы вызывали onBindviewhohlder он проверяет совпадает ли viewholder если нет то position .
+    но как так мы определяем position каждый раз viewtype будет у всех разных и он заново создаст
+    новый обьект и мы также вернулись первоначалной проблеме . сколько объектов столько view создастся
+    заново . но они будут создаваться при скроле а не сразу . вот и вся разница
+
      */
 
     override fun onViewRecycled(viewHolder: ShopItemViewHolder) {
         super.onViewRecycled(viewHolder)
         viewHolder.tvName.text =""
         viewHolder.tvCount.text = ""
-        viewHolder.tvName.setTextColor(ContextCompat.getColor(viewHolder.view.context , android.R.color.white))
+
         //установлены значения по умолчанию
 
+    }
+    companion object {
+        val VIEW_TYPE_ENABLED = 0
+        val VIEW_TYPE_DISABLED = 1
+
+        const val  MAX_POOL_SIZE = 20
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,22 +6,10 @@
     android:layout_height="match_parent"
     tools:context=".presentation.MainActivity">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <LinearLayout
-            android:id="@+id/ll_shop_list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"/>
-    </ScrollView>
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_shop_list"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### lesson 10 
здесь мы прошлись по recyclerView . нельзя исползывать метод getItemViewType . 
когда мы переопределяем  getItemViewType (position : viewType)
{
return position

}
здесь все элементы списка создаються заново . потому что не одинаковый viewType . мы пришли обратно к тому что и метод iinflate и метод findviewbyid переопределялись и засорялся процессор  . 

2. Метод getItemViewType - переопределяйте метод если для разных элементов исползуется разные макеты . 
3. Значение viewType исползуйте внутри метода onCreateViewHolder . 
4. ViewHolder скрытый с экрана отпраляется  в пул вьюхолдеров .
5. recyclerview не может переисползывать ViewHolder если его тип отличается от типа элемента который исползуеться . 
6. пул вьюхолдеров имеет огрониченный размер . его можно переопределять и при новывх viewholder od старые удаляются .
7. 
